### PR TITLE
arm_dynarmic: Check if jit is nullptr when preparing reschedule

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -257,6 +257,9 @@ void ARM_Dynarmic::LoadContext(const ThreadContext& ctx) {
 }
 
 void ARM_Dynarmic::PrepareReschedule() {
+    if (jit == nullptr)
+        return;
+
     jit->HaltExecution();
 }
 


### PR DESCRIPTION
Prevents crash with multiprocess loading.